### PR TITLE
Add IChatClient support to DeepSeekClient

### DIFF
--- a/DeepSeek.NET/Classes/ChatRequest/ChatRequest.cs
+++ b/DeepSeek.NET/Classes/ChatRequest/ChatRequest.cs
@@ -50,13 +50,13 @@ public class ChatRequest
     /// <summary>
     /// Sampling temperature, between 0 and 2. Higher values like 0.8 make the output more random, while lower values like 0.2 make it more focused and deterministic. We generally recommend adjusting this or top_p, but not both.
     /// </summary>
-    public long Temperature { get; set; } = 1;
+    public double Temperature { get; set; } = 1;
 
     /// <summary>
     /// An alternative to sampling with temperature, the model considers the results of the top_p probability tokens. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend adjusting this or temperature, but not both.
     /// </summary>
     [JsonPropertyName("top_p")]
-    public long TopP { get; set; } = 1;
+    public double TopP { get; set; } = 1;
 
     /// <summary>
     /// Whether to return the log probabilities of the output tokens. If true, the log probabilities of each output token are returned in the content of the message.

--- a/DeepSeek.NET/DeepSeek.NET.csproj
+++ b/DeepSeek.NET/DeepSeek.NET.csproj
@@ -13,6 +13,7 @@
     <RepositoryUrl>https://github.com/luisllamasbinaburo/deepseeknet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,6 +25,10 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.1.0-preview.1.25064.3" />
   </ItemGroup>
 
 </Project>

--- a/DeepSeek.NET/DeepSeekClient.cs
+++ b/DeepSeek.NET/DeepSeekClient.cs
@@ -1,4 +1,6 @@
 ﻿using DeepSeek.Classes;
+using Microsoft.Extensions.AI;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -7,11 +9,10 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Unicode;
 using System.Threading.Channels;
-using static System.Net.WebRequestMethods;
 
 namespace DeepSeek;
 
-public class DeepSeekClient : IDisposable
+public class DeepSeekClient : IChatClient, IDisposable
 {
     private readonly HttpClient _httpClient;
     private bool _disposed;
@@ -118,11 +119,16 @@ public class DeepSeekClient : IDisposable
         var channel = Channel.CreateUnbounded<Choice>();
         _ = Task.Run(async () =>
         {
-            while (!reader.EndOfStream)
+            while (true)
             {
                 var line = await reader.ReadLineAsync();
+                if (line is null)
+                {
+                    break;
+                }
+
                 line = line?.Replace("data:", "").Trim();
-                
+
                 if (line == Constants.StreamDoneSign) break;
                 if (string.IsNullOrWhiteSpace(line)) continue;
 
@@ -151,4 +157,171 @@ public class DeepSeekClient : IDisposable
         _disposed = true;
         GC.SuppressFinalize(this);
     }
+
+    #region IChatClient
+    async Task<ChatCompletion> IChatClient.CompleteAsync(IList<ChatMessage> chatMessages, ChatOptions? options, CancellationToken cancellationToken)
+    {
+        ChatRequest request = CreateChatRequest(chatMessages, options);
+
+        ChatResponse? response = await ChatAsync(request, cancellationToken);
+        ThrowIfRequestFailed(response);
+
+        return CreateChatCompletion(response);
+    }
+
+    async IAsyncEnumerable<StreamingChatCompletionUpdate> IChatClient.CompleteStreamingAsync(IList<ChatMessage> chatMessages, ChatOptions? options, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        IAsyncEnumerable<Choice>? choices = await ChatStreamAsync(CreateChatRequest(chatMessages, options), cancellationToken);
+        ThrowIfRequestFailed(choices);
+
+        await foreach (var choice in choices)
+        {
+            yield return CreateStreamingChatCompletionUpdate(choice);
+        }
+    }
+
+    object? IChatClient.GetService(Type serviceType, object? serviceKey) =>
+        serviceKey is null && serviceType?.IsInstanceOfType(this) is true ? this : null;
+
+    ChatClientMetadata IChatClient.Metadata { get; } = new("deepseek", new Uri(Constants.BaseAddress));
+
+    private void ThrowIfRequestFailed([NotNull] object? response)
+    {
+        if (response is null)
+        {
+            throw new InvalidOperationException(string.IsNullOrWhiteSpace(ErrorMessage) ?
+                $"Failed to get response" :
+                $"Failed to get response: {ErrorMessage}");
+        }
+    }
+
+    private static ChatCompletion CreateChatCompletion(ChatResponse response)
+    {
+        ChatCompletion completion = new([])
+        {
+            CompletionId = response.Id,
+            ModelId = response.Model,
+            CreatedAt = DateTimeOffset.FromUnixTimeSeconds(response.Created)
+        };
+
+        foreach (var choice in response.Choices)
+        {
+            completion.FinishReason ??= CreateFinishReason(choice);
+            completion.Choices.Add(CreateChatMessage(choice));
+        }
+
+        if (response.Usage is Usage usage)
+        {
+            completion.Usage = new()
+            {
+                InputTokenCount = (int)usage.PromptTokens,
+                TotalTokenCount = (int)usage.TotalTokens,
+                OutputTokenCount = (int)usage.CompletionTokens,
+                AdditionalCounts = new()
+                {
+                    [nameof(usage.PromptCacheHitTokens)] = (int)usage.PromptCacheHitTokens,
+                    [nameof(usage.PromptCacheMissTokens)] = (int)usage.PromptCacheMissTokens,
+                },
+            };
+        }
+
+        return completion;
+    }
+
+    private static ChatFinishReason? CreateFinishReason(Choice choice) => 
+        choice.FinishReason switch
+        {
+            "stop" => ChatFinishReason.Stop,
+            "length" => ChatFinishReason.Length,
+            "content_filter" => ChatFinishReason.ContentFilter,
+            "tool_calls" => ChatFinishReason.ToolCalls,
+            _ => null,
+        };
+
+    private static ChatMessage CreateChatMessage(Choice choice)
+    {
+        Message? choiceMessage = choice.Delta ?? choice.Message;
+
+        ChatMessage m = new()
+        {
+            RawRepresentation = choice,
+            Role = CreateChatRole(choiceMessage),
+            Text = choiceMessage?.Content
+        };
+
+        if (choice.Logprobs is not null)
+        {
+            (m.AdditionalProperties ??= []).Add(nameof(choice.Logprobs), choice.Logprobs);
+        }
+
+        return m;
+    }
+
+    private static StreamingChatCompletionUpdate CreateStreamingChatCompletionUpdate(Choice choice)
+    {
+        Message? choiceMessage = choice.Delta ?? choice.Message;
+
+        StreamingChatCompletionUpdate update = new()
+        {
+            ChoiceIndex = (int)choice.Index,
+            FinishReason = CreateFinishReason(choice),
+            RawRepresentation = choice,
+            Role = CreateChatRole(choiceMessage),
+            Text = choiceMessage?.Content
+        };
+
+        if (choice.Logprobs is not null)
+        {
+            (update.AdditionalProperties ??= []).Add(nameof(choice.Logprobs), choice.Logprobs);
+        }
+
+        return update;
+    }
+
+    private static ChatRole CreateChatRole(Message? m) =>
+        m?.Role switch
+        {
+            "user" => ChatRole.User,
+            "system" => ChatRole.System,
+            _ => ChatRole.Assistant,
+        };
+
+    private static ChatRequest CreateChatRequest(IList<ChatMessage> chatMessages, ChatOptions? options)
+    {
+        ChatRequest request = new();
+
+        if (options is not null)
+        {
+            if (options.ModelId is not null) request.Model = options.ModelId;
+            if (options.FrequencyPenalty is not null) request.FrequencyPenalty = options.FrequencyPenalty.Value;
+            if (options.MaxOutputTokens is not null) request.MaxTokens = options.MaxOutputTokens.Value;
+            if (options.PresencePenalty is not null) request.PresencePenalty = options.PresencePenalty.Value;
+            if (options.StopSequences is not null) request.Stop = [.. options.StopSequences];
+            if (options.Temperature is not null) request.Temperature = options.Temperature.Value;
+            if (options.TopP is not null) request.TopP = options.TopP.Value;
+            if (options.AdditionalProperties?.TryGetValue(nameof(request.Logprobs), out bool logprobs) is true) request.Logprobs = logprobs;
+            if (options.AdditionalProperties?.TryGetValue(nameof(request.TopLogprobs), out int topLogprobs) is true) request.TopLogprobs = topLogprobs;
+        }
+
+        List<Message> messages = [];
+        foreach (var message in chatMessages)
+        {
+            string role;
+            if (message.Role == ChatRole.User) role = "user";
+            else if (message.Role == ChatRole.Assistant) role = "assistant";
+            else if (message.Role == ChatRole.System) role = "system";
+            else continue;
+
+            string text = string.Concat(message.Contents.OfType<TextContent>());
+
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                messages.Add(new() { Content = text, Role = role });
+            }
+        }
+
+        request.Messages = messages.ToArray();
+        return request;
+    }
+    #endregion
 }


### PR DESCRIPTION
I don't have a deepseek API key, but this should provide a working or almost-working implementation of IChatClient. It'll enable your client to be used with anything else that works in terms of the Microsoft.Extensions.AI.Abstractions IChatClient interface.

For more information, see https://learn.microsoft.com/en-us/dotnet/ai/ai-extensions.